### PR TITLE
Bugfix - invalid online state after restart

### DIFF
--- a/mqtt.ino
+++ b/mqtt.ino
@@ -84,7 +84,7 @@ void reconnect() {
     Serial.print("Attempting MQTT connection...");
     // Create a random client ID
     String clientId = "ESP8266Client-";
-    clientId += String(random(0xffff), HEX);
+    clientId += String(WiFi.macAddress());
     // Attempt to connect
     if (client.connect(clientId.c_str(), MQTT_USERNAME, MQTT_PASSWORD,
                        MQTT_STATUS_TOPIC, 0, true, OFFLINE_PAYLOAD)) {


### PR DESCRIPTION
When the device was restarted it reconnected with a different client id, the old client id's last will overwritten the online state, used fix client id to fix it